### PR TITLE
Add inference script and support for different input image shapes

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,115 @@
+VGGT License
+
+v1 Last Updated: July 29, 2025
+
+“Acceptable Use Policy” means the Acceptable Use Policy, applicable to Research Materials, that is incorporated into this Agreement.
+
+“Agreement” means the terms and conditions for use, reproduction, distribution and modification of the Research Materials set forth herein.
+
+
+“Documentation” means the specifications, manuals and documentation accompanying 
+Research Materials distributed by Meta.
+
+
+“Licensee” or “you” means you, or your employer or any other person or entity (if you are entering into this Agreement on such person or entity’s behalf), of the age required under applicable laws, rules or regulations to provide legal consent and that has legal authority to bind your employer or such other person or entity if you are entering in this Agreement on their behalf.
+
+“Meta” or “we” means Meta Platforms Ireland Limited (if you are located in or, if you are an entity, your principal place of business is in the EEA or Switzerland) and Meta Platforms, Inc. (if you are located outside of the EEA or Switzerland).
+“Research Materials” means, collectively, Documentation and the models, software and algorithms, including machine-learning model code, trained model weights, inference-enabling code, training-enabling code, fine-tuning enabling code, demonstration materials and other elements of the foregoing distributed by Meta and made available under this Agreement.
+
+By clicking “I Accept” below or by using or distributing any portion or element of the Research Materials, you agree to be bound by this Agreement.
+
+
+1. License Rights and Redistribution.
+
+
+a. Grant of Rights. You are granted a non-exclusive, worldwide, non-transferable and royalty-free limited license under Meta’s intellectual property or other rights owned by Meta embodied in the Research Materials to use, reproduce, distribute, copy, create derivative works of, and make modifications to the Research Materials.  
+ 
+b. Redistribution and Use.  
+
+
+i. Distribution of Research Materials, and any derivative works thereof, are subject to the terms of this Agreement. If you distribute or make the Research Materials, or any derivative works thereof, available to a third party, you may only do so under the terms of this Agreement. You shall also provide a copy of this Agreement to such third party.
+
+
+ii.  If you submit for publication the results of research you perform on, using, or otherwise in connection with Research Materials, you must acknowledge the use of Research Materials in your publication.
+
+
+iii. Your use of the Research Materials must comply with applicable laws and regulations (including Trade Control Laws) and adhere to the Acceptable Use Policy, which is hereby incorporated by reference into this Agreement.
+2. User Support. Your  use of the Research Materials is done at your own discretion; Meta does not process any information nor provide any service in relation to such use.  Meta is under no obligation to provide any support services for the Research Materials. Any support provided is “as is”, “with all faults”, and without warranty of any kind.
+
+
+3. Disclaimer of Warranty. UNLESS REQUIRED BY APPLICABLE LAW, THE RESEARCH MATERIALS AND ANY OUTPUT AND RESULTS THEREFROM ARE PROVIDED ON AN “AS IS” BASIS, WITHOUT WARRANTIES OF ANY KIND, AND META DISCLAIMS ALL WARRANTIES OF ANY KIND, BOTH EXPRESS AND IMPLIED, INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE. YOU ARE SOLELY RESPONSIBLE FOR DETERMINING THE APPROPRIATENESS OF USING OR REDISTRIBUTING THE RESEARCH MATERIALS AND ASSUME ANY RISKS ASSOCIATED WITH YOUR USE OF THE RESEARCH MATERIALS AND ANY OUTPUT AND RESULTS.
+ 
+4. Limitation of Liability. IN NO EVENT WILL META OR ITS AFFILIATES BE LIABLE UNDER ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, TORT, NEGLIGENCE, PRODUCTS LIABILITY, OR OTHERWISE, ARISING OUT OF THIS AGREEMENT, FOR ANY LOST PROFITS OR ANY DIRECT OR INDIRECT, SPECIAL, CONSEQUENTIAL, INCIDENTAL, EXEMPLARY OR PUNITIVE DAMAGES, EVEN IF META OR ITS AFFILIATES HAVE BEEN ADVISED OF THE POSSIBILITY OF ANY OF THE FOREGOING.
+ 
+5. Intellectual Property.
+
+
+a. Subject to Meta’s ownership of Research Materials and derivatives made by or for Meta, with respect to any derivative works and modifications of the Research Materials that are made by you, as between you and Meta, you are and will be the owner of such derivative works and modifications.
+ 
+b. If you institute litigation or other proceedings against Meta or any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Research Materials, outputs or results, or any portion of any of the foregoing, constitutes infringement of intellectual property or other rights owned or licensable by you, then any licenses granted to you under this Agreement shall terminate as of the date such litigation or claim is filed or instituted. You will indemnify and hold harmless Meta from and against any claim by any third party arising out of or related to your use or distribution of the Research Materials.
+ 
+6. Term and Termination. The term of this Agreement will commence upon your acceptance of this Agreement or access to the Research Materials and will continue in full force and effect until terminated in accordance with the terms and conditions herein. Meta may terminate this Agreement if you are in breach of any term or condition of this Agreement. Upon termination of this Agreement, you shall delete and cease use of the Research Materials. Sections 5, 6 and 9 shall survive the termination of this Agreement. 
+ 
+7. Governing Law and Jurisdiction. This Agreement will be governed and construed under the laws of the State of California without regard to choice of law principles, and the UN Convention on Contracts for the International Sale of Goods does not apply to this Agreement. The courts of California shall have exclusive jurisdiction of any dispute arising out of this Agreement. 
+
+
+8. Modifications and Amendments. Meta may modify this Agreement from time to time; provided that they are similar in spirit to the current version of the Agreement, but may differ in detail to address new problems or concerns. All such changes will be effective immediately. Your continued use of the Research Materials after any modification to this Agreement constitutes your agreement to such modification. Except as provided in this Agreement, no modification or addition to any provision of this Agreement will be binding unless it is in writing and signed by an authorized representative of both you and Meta.
+
+
+Acceptable Use Policy 
+
+Meta seeks to further understanding of new and existing research domains with the mission of advancing the state-of-the-art in artificial intelligence through open research for the benefit of all. 
+
+As part of this mission, Meta makes certain research materials available for use in accordance with this Agreement (including the Acceptable Use Policy). Meta is committed to promoting the safe and responsible use of such research materials.  
+
+Prohibited Uses
+
+You agree you will not use, or allow others to use, Research Materials to:
+
+ Violate the law or others’ rights, including to:
+Engage in, promote, generate, contribute to, encourage, plan, incite, or further illegal or unlawful activity or content, such as:
+Violence or terrorism
+Exploitation or harm to children, including the solicitation, creation, acquisition, or dissemination of child exploitative content or failure to report Child Sexual Abuse Material
+Human trafficking, exploitation, and sexual violence
+The illegal distribution of information or materials to minors, including obscene materials, or failure to employ legally required age-gating in connection with such information or materials.
+Sexual solicitation
+Any other criminal activity
+
+Engage in, promote, incite, or facilitate the harassment, abuse, threatening, or bullying of individuals or groups of individuals
+
+Engage in, promote, incite, or facilitate discrimination or other unlawful or harmful conduct in the provision of employment, employment benefits, credit, housing, other economic benefits, or other essential goods and services
+
+Engage in the unauthorized or unlicensed practice of any profession including, but not limited to, financial, legal, medical/health, or related professional practices
+
+Collect, process, disclose, generate, or infer health, demographic, or other sensitive personal or private information about individuals without rights and consents required by applicable laws
+
+Engage in or facilitate any action or generate any content that infringes, misappropriates, or otherwise violates any third-party rights, including the outputs or results of any technology using Research Materials
+
+Create, generate, or facilitate the creation of malicious code, malware, computer viruses or do anything else that could disable, overburden, interfere with or impair the proper working, integrity, operation or appearance of a website or computer system
+
+2. Engage in, promote, incite, facilitate, or assist in the planning or development of activities that present a risk of death or bodily harm to individuals, including use of research artifacts related to the following:
+
+Military, warfare, nuclear industries or applications, espionage, use for materials or activities that are subject to the International Traffic Arms Regulations (ITAR) maintained by the United States Department of State
+
+Guns and illegal weapons (including weapon development)
+
+Illegal drugs and regulated/controlled substances
+Operation of critical infrastructure, transportation technologies, or heavy machinery
+
+Self-harm or harm to others, including suicide, cutting, and eating disorders
+Any content intended to incite or promote violence, abuse, or any infliction of bodily harm to an individual
+
+3. Intentionally deceive or mislead others, including use of Research Materials related to the following:
+
+ Generating, promoting, or furthering fraud or the creation or promotion of disinformation
+ Generating, promoting, or furthering defamatory content, including the creation of defamatory statements, images, or other content
+
+Generating, promoting, or further distributing spam
+
+ Impersonating another individual without consent, authorization, or legal right
+
+Representing that outputs of research materials or outputs from technology using Research Materials are human-generated
+
+Generating or facilitating false online engagement, including fake reviews and other means of fake online engagement
+
+4. Fail to appropriately disclose to end users any known dangers of your Research Materials.

--- a/README.md
+++ b/README.md
@@ -104,4 +104,5 @@ python eval_scannet.py --input_frame 1000
 
 
 ## ⚖️ License
-See the [LICENSE](./LICENSE.txt) file for details about the license under which this code is made available.
+The FastVGGT codebase follows VGGT's license, please refer to ./LICENSE.txt for applicable terms.
+

--- a/README.md
+++ b/README.md
@@ -104,5 +104,7 @@ python eval_scannet.py --input_frame 1000
 
 
 ## ⚖️ License
-The FastVGGT codebase follows VGGT's license, please refer to ./LICENSE.txt for applicable terms.
+The FastVGGT codebase follows VGGT's license, please refer to [LICENSE](./LICENSE.txt) for applicable terms.
+
+Please note that only this [model checkpoint](https://huggingface.co/facebook/VGGT-1B-Commercial) allows commercial usage.
 

--- a/inference.py
+++ b/inference.py
@@ -1,0 +1,45 @@
+import numpy as np
+import torch
+import os
+import cv2
+from pathlib import Path
+from vggt.models.vggt import VGGT
+from vggt.utils.eval_utils import (
+    get_vgg_input_imgs,
+    load_images_rgb,
+    infer_vggt_and_reconstruct,
+    get_sorted_image_paths
+)
+
+# force bfloat16
+dtype = torch.bfloat16
+
+# load VGGT
+model = VGGT(merging=0, vis_attn_map=None)
+ckpt = torch.load("./checkpoints/model_tracker_fixed_e20.pt", map_location="cpu")
+incompat = model.load_state_dict(ckpt, strict=False)
+model = model.cuda().eval()
+model = model.to(torch.bfloat16)
+
+# load Images
+images_dir = Path('./kitchen/images')
+image_paths = get_sorted_image_paths(images_dir)
+images = load_images_rgb(image_paths)
+print(f"Loaded {len(images)} images with shape: {images[0].shape if images else 'N/A'}")
+
+images_array = np.stack(images)
+vgg_input = get_vgg_input_imgs(images_array)
+
+
+# Inference
+(
+    extrinsic_np,
+    intrinsic_np,
+    all_world_points,
+    all_cam_to_world_mat,
+    inference_time_ms,
+) = infer_vggt_and_reconstruct(
+    model, vgg_input, dtype, 3.0
+)
+
+

--- a/vggt/layers/attention.py
+++ b/vggt/layers/attention.py
@@ -54,7 +54,7 @@ class Attention(nn.Module):
         self.rope = rope
         self.kv_group_size = kv_group_size
 
-    def forward(self, x: Tensor, pos=None, global_merging=None) -> Tensor:
+    def forward(self, x: Tensor, pos=None, global_merging=None, H=0, W=0) -> Tensor:
         merge_num = list(range(24))
 
         B, N, C = x.shape
@@ -158,7 +158,7 @@ class Attention(nn.Module):
             r = int(x.shape[1] * merge_ratio)
 
             m, u = token_merge_bipartite2d(
-                x, 37, 28, 2, 2, r, False, generator, enable_protection=True
+                x, W//14, H//14, 2, 2, r, False, generator, enable_protection=True
             )
 
             m_a, u_a = (m, u)
@@ -205,7 +205,7 @@ class Attention(nn.Module):
 
 class MemEffAttention(Attention):
     def forward(
-        self, x: Tensor, attn_bias=None, pos=None, global_merging=None
+        self, x: Tensor, attn_bias=None, pos=None, global_merging=None, H=0, W=0
     ) -> Tensor:
         assert (
             pos is None or self.rope is not None

--- a/vggt/layers/block.py
+++ b/vggt/layers/block.py
@@ -79,9 +79,9 @@ class Block(nn.Module):
 
         self.sample_drop_ratio = drop_path
 
-    def forward(self, x: Tensor, pos=None, global_merging=None) -> Tensor:
+    def forward(self, x: Tensor, pos=None, global_merging=None, H=0, W=0) -> Tensor:
         norm1_output = self.norm1(x)
-        attn_output = self.attn(norm1_output, pos=pos, global_merging=global_merging)
+        attn_output = self.attn(norm1_output, pos=pos, global_merging=global_merging, H=H, W=W)
         del norm1_output
         x = x + self.ls1(attn_output)
         del attn_output

--- a/vggt/models/aggregator.py
+++ b/vggt/models/aggregator.py
@@ -349,6 +349,8 @@ class Aggregator(nn.Module):
                     tokens, global_idx, global_intermediates = (
                         self._process_global_attention(
                             tokens,
+                            H,
+                            W,
                             B,
                             S,
                             P,
@@ -414,6 +416,8 @@ class Aggregator(nn.Module):
     def _process_global_attention(
         self,
         tokens,
+        H,
+        W,
         B,
         S,
         P,
@@ -440,6 +444,8 @@ class Aggregator(nn.Module):
                 tokens,
                 pos=pos,
                 global_merging=global_merging,
+                H=H,
+                W=W,
             )
             global_idx += 1
             if need_intermediates:

--- a/vggt/models/vggt.py
+++ b/vggt/models/vggt.py
@@ -101,7 +101,6 @@ class VGGT(nn.Module, PyTorchModelHubMixin):
         # If without batch dimension, add it
         if len(images.shape) == 4:
             images = images.unsqueeze(0)
-
         if query_points is not None and len(query_points.shape) == 2:
             query_points = query_points.unsqueeze(0)
 

--- a/vggt/utils/eval_utils.py
+++ b/vggt/utils/eval_utils.py
@@ -370,15 +370,15 @@ def get_vgg_input_imgs(images: np.ndarray):
         img = Image.fromarray(image, mode="RGB")
         width, height = img.size
         # Resize image, maintain aspect ratio, ensure height is multiple of 14
-        new_width = 518
+        new_width = 532
         new_height = round(height * (new_width / width) / 14) * 14
         img = img.resize((new_width, new_height), Image.Resampling.BICUBIC)
         img = to_tensor(img)  # Convert to tensor (0, 1)
 
         # If height exceeds 518, perform center cropping
-        if new_height > 518:
-            start_y = (new_height - 518) // 2
-            img = img[:, start_y : start_y + 518, :]
+        if new_height > new_width:
+            start_y = (new_height - new_width) // 2
+            img = img[:, start_y : start_y + new_width, :]
 
         vgg_input_images.append(img)
     vgg_input_images = torch.stack(vgg_input_images)


### PR DESCRIPTION
Brief: 
- Add H and W parameters in vggt.py、eval_utils.py、aggregator.py、attention.py，enabling the model to automatically handle image sizes.
- Add inference.py

Hi! I've made a couple of improvements to the project.

**Problem:**
1. The repository was missing an `inference.py` script to run the model on custom datasets.
2. In the attention mechanism, the token height and width were hardcoded. This isn't ideal, as they should adapt to the processed image dimensions.

**Solution:**
1. I've added a new `inference.py` script.
2. I've modified the attention code to automatically calculate the tokens based on the image size (specifically, `W / 14` and `H / 14` in attention.py:161).

I have tested the code successfully. This makes the model more robust and easier to use for inference. Please let me know if you have any feedback!