### PR TITLE
attention图像尺寸动态调整与chunk_size非负性定义

### DIFF
--- a/merging/merge.py
+++ b/merging/merge.py
@@ -217,7 +217,8 @@ def token_merge_bipartite2d(
 
         r = min(a.shape[1], r)
         num_src_actual = a.shape[1]
-        chunk_size = min(5000, num_src_actual)
+        # Ensure chunk_size is at least 1 to avoid range() error
+        chunk_size = max(1, min(5000, num_src_actual))
 
         node_max = torch.empty(B, num_src_actual, device=a.device, dtype=a.dtype)
         node_idx = torch.empty(B, num_src_actual, device=a.device, dtype=torch.long)


### PR DESCRIPTION
我在调用FastVGGT时发现两个问题

1. Attention图像尺寸问题
FastVGGT似乎不是根据实际输入图像尺寸动态计算的，patch_width 和 patch_height 被设置为固定的默认值(37,28)。当输入图像尺寸变化时，会导致token数量不匹配。

2. chunk_size缺少非负性定义
在token_merge_bipartite2d函数中，chunk_size可能为0，导致fast_similarity_chunks函数中的range()调用失败。建议修改merge.py文件，确保chunk_size至少为1。